### PR TITLE
bump windows & strum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,11 @@ documentation = "https://docs.rs/crate/shroud/latest"
 keywords = ["directx", "hacking", "games", "hook"]
 
 [dependencies]
-windows = { version = "0.48.0", features = [
-    "Win32_Foundation",
-    "Win32_System_SystemServices",
-    "Win32_System_Threading",
-    "Win32_System_LibraryLoader",
-
-    "Win32_UI_WindowsAndMessaging",
-    "Win32_Graphics_Gdi",
-    "Win32_UI_Input_KeyboardAndMouse",
-
-    "Win32_Graphics_Direct3D",
-    "Win32_Graphics_Dxgi_Common",
-] }
+windows = { version = "0.51.1", features = ["Win32_Foundation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_LibraryLoader", "Win32_UI_WindowsAndMessaging", "Win32_Graphics_Gdi", "Win32_UI_Input_KeyboardAndMouse", "Win32_Graphics_Direct3D", "Win32_Graphics_Dxgi_Common"] }
 thiserror = "1.0.37"
 
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 
 [features]
 default = ["directx9", "directx10", "directx11", "directx12"]

--- a/examples/shroud-debug/Cargo.toml
+++ b/examples/shroud-debug/Cargo.toml
@@ -9,10 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 shroud = { path = "../../", features = ["directx9", "directx11", "directx12"] }
-windows = { version = "0.48.0", features = [
-    "Win32_Foundation",
-    "Win32_System_SystemServices",
-    "Win32_Security",
-    "Win32_System_Threading",
-    "Win32_System_Console",
-] }
+windows = { version = "0.51.1", features = ["Win32_Foundation", "Win32_System_SystemServices", "Win32_Security", "Win32_System_Threading", "Win32_System_Console"] }

--- a/examples/shroud-debug/src/lib.rs
+++ b/examples/shroud-debug/src/lib.rs
@@ -38,7 +38,8 @@ unsafe extern "system" fn start_routine(_parameter: *mut std::ffi::c_void) -> u3
 #[allow(non_snake_case)]
 pub extern "system" fn DllMain(dll_module: HMODULE, call_reason: u32, _reserved: usize) -> BOOL {
     if call_reason == DLL_PROCESS_ATTACH {
-        unsafe { AllocConsole() };
+        let _ = unsafe { AllocConsole() };
+
         println!("Attached.");
 
         let thread = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub(crate) fn get_process_window() -> Option<HWND> {
             Some(enum_windows_callback),
             std::mem::transmute::<_, LPARAM>(&mut output as *mut HWND),
         )
+        .ok()?
     };
 
     match output.0 == 0 {


### PR DESCRIPTION
This commit bumps the used windows version from 0.48 to 0.51. It also bumps strum from 0.24 to 0.25. Everything builds as expected.